### PR TITLE
Update API versioning and simplify response structure

### DIFF
--- a/src/routes/v1/common/index.ts
+++ b/src/routes/v1/common/index.ts
@@ -209,7 +209,6 @@ export const commonRoutes = new Elysia({ prefix: '/common' })
             return {
                 name: 'LetLetMe API',
                 version: '1.0.0',
-                environment: process.env.NODE_ENV || 'development',
             };
         },
         {

--- a/src/routes/v1/index.ts
+++ b/src/routes/v1/index.ts
@@ -8,7 +8,7 @@ import { summaryRoutes } from './summary/index';
 import { tournamentRoutes } from './tournament/index';
 
 // Create a versioned API router that combines all route groups
-export const v1Routes = new Elysia({ prefix: '/api/v1' })
+export const v1Routes = new Elysia({ prefix: '/v1' })
     .use(commonRoutes)
     .use(entryRoutes)
     .use(liveRoutes)


### PR DESCRIPTION
Change the API prefix from '/api/v1' to '/v1' for a cleaner route structure and remove the environment variable from API responses to streamline the response format.