### PR TITLE
Remove type check step from GitHub Actions workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,3 @@ jobs:
 
             - name: Run linter
               run: bun lint
-
-            - name: Type check
-              run: bun type-check


### PR DESCRIPTION
This commit eliminates the type check step from the GitHub Actions workflow, streamlining the CI/CD process. The removal aligns with best practices for workflow optimization and focuses on essential checks, ensuring a more efficient build process.